### PR TITLE
Fix: Open footer social media links in a new tab

### DIFF
--- a/client/src/components/HomePage.jsx
+++ b/client/src/components/HomePage.jsx
@@ -123,9 +123,9 @@ const HomePage = () => {
       <footer className="footer animate-on-scroll">
         <p>&copy; {new Date().getFullYear()} JustCoding. Built with love, learning, and late nights by Anu 💌🌸.</p>
         <div className="social-icons">
-          <a href="https://x.com/_Anuuu_Soniii_" aria-label="Twitter"><FaTwitter /> Twitter</a>
-          <a href="https://github.com/ANU-2524/" aria-label="GitHub"><FaGithub /> GitHub</a>
-          <a href="https://www.linkedin.com/in/anu--soni/" aria-label="LinkedIn"><FaLinkedin /> LinkedIn</a>
+          <a href="https://x.com/_Anuuu_Soniii_" aria-label="Twitter" target="_blank" rel="noopener noreferrer"><FaTwitter /> Twitter</a>
+          <a href="https://github.com/ANU-2524/" aria-label="GitHub" target="_blank" rel="noopener noreferrer"><FaGithub /> GitHub</a>
+          <a href="https://www.linkedin.com/in/anu--soni/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer"><FaLinkedin /> LinkedIn</a>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## 📝 Summary

Updated the footer social media links to open in a new browser tab for better user experience and added recommended security attributes under ECWoC26.

---

## 🔗 Related Issue

Closes #73 

---

## ✅ Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests

---

## 🧪 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (please explain)

---

## 📸 Screenshots / Recordings (if applicable)

Not applicable (link behavior change only).

---

## ✔️ Checklist

Please confirm the following:

- [x] My code follows the existing code style
- [x] I have tested my changes locally
- [ ] I have updated documentation if required
- [x] I have linked the related issue
- [x] This PR does not break existing functionality

---

## 💬 Additional Notes

This is a small UI/UX improvement to ensure external social media links do not navigate users away from the main site.
