### PR TITLE
Scroll-to-top button overlap issue solved

### DIFF
--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -27,7 +27,7 @@ const ScrollToTop = () => {
       aria-label="Scroll to top"
       style={{
         position: "fixed",
-        bottom: "24px",
+        bottom: "90px",
         right: "24px",
         zIndex: 1000,
         width: "44px",


### PR DESCRIPTION
## 📝 Summary

Scroll-to-top button was overlapping the chat-with-bot button, so i fixed that.


---

## ✅ Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests

---

## 🧪 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (please explain)

---

## 📸 Screenshots / Recordings (if applicable)

<img width="219" height="239" alt="Screenshot 2026-01-06 175925" src="https://github.com/user-attachments/assets/eef2d739-5ede-4d10-9634-8c38f7d0edfc" />

---

## ✔️ Checklist

Please confirm the following:

- [x] My code follows the existing code style
- [x] I have tested my changes locally
- [x] I have updated documentation if required
- [x] I have linked the related issue
- [x] This PR does not break existing functionality

---

## 💬 Additional Notes

@ANU-2524 Kindly check the PR, now the issue has been resolved.
