### PR TITLE
Inconsistent Error Messages and Handling Across Routes

### DIFF
--- a/server/routes/challenges.js
+++ b/server/routes/challenges.js
@@ -331,17 +331,18 @@ router.post('/contests/:slug/join', async (req, res) => {
     // Check if already joined
     const existing = contest.participants.find(p => p.odId === odId);
     if (existing) {
-      return res.json({ message: 'Already joined', participant: existing });
+      return res.json({ participant: existing });
     }
 
     if (contest.participants.length >= contest.maxParticipants) {
       return res.status(400).json({ error: 'Contest is full' });
     }
 
-    contest.participants.push({ odId, odName: odName || 'Anonymous' });
+    const newParticipant = { odId, odName: odName || 'Anonymous' };
+    contest.participants.push(newParticipant);
     await contest.save();
 
-    res.json({ message: 'Joined successfully' });
+    res.json({ participant: newParticipant });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
## 📝 Summary

Error handling was inconsistent across routes in server/routes/challenges.js, leading to varied error messages and responses that could confuse clients and complicate debugging. Specifically, success messages in the join contest route used a { message: '...' } format, differing from the standard JSON structures used elsewhere.
### Root Cause
Most routes used consistent error formats like { error: 'message' } with appropriate HTTP status codes (400 for bad requests, 404 for not found, 403 for forbidden, 500 for server errors).
The join contest route (POST /contests/:slug/join) had success responses that included { message: 'Already joined', participant: existing } and { message: 'Joined successfully' }, which deviated from the uniform JSON response patterns.

---

## 🔗 Related Issue

Closes #249

---

## ✅ Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests

---

## 🧪 How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested (please explain)

---



## ✔️ Checklist

Please confirm the following:

- [x] My code follows the existing code style
- [x] I have tested my changes locally
- [x] I have updated documentation if required
- [x] I have linked the related issue
- [x] This PR does not break existing functionality

---


